### PR TITLE
Fix save palette rgb cololor bug

### DIFF
--- a/color-class.js
+++ b/color-class.js
@@ -6,7 +6,7 @@ function getRandomIndex(array) {
 
 class Color {
   constructor() {
-    this.hex = this.getNewHex();
+    this.hex = `#${this.getNewHex()}`;
     this.locked = false;
   }
 

--- a/palette-class.js
+++ b/palette-class.js
@@ -13,7 +13,7 @@ class Palette {
     for (var i = 0; i < currentPalette.length; i++) {
       var newColor = new Color ();
       if (currentPalette[i].classList.contains('unlocked')) {
-        currentPalette[i].style.backgroundColor = `#${newColor.hex}`
+        currentPalette[i].style.backgroundColor = `${newColor.hex}`
       }
       else if (currentPalette[i].classList.contains('locked')) {
         newColor.hex = currentPalette[i].style.backgroundColor;
@@ -21,7 +21,7 @@ class Palette {
       this.colors.push(newColor);
     }
     for (var i = 0; i < hexCode.length; i++) {
-      hexCode[i].innerText = `#${this.colors[i].hex}`;
+      hexCode[i].innerText = `${this.colors[i].hex}`;
     }
   }
 

--- a/scripts.js
+++ b/scripts.js
@@ -63,7 +63,7 @@ function displayPalette() {
 
       pallet +=  `
         <section class="palettes_color_mini" data-index="0">
-          <section class="palettes_current mini locked" style="background-color:#${savedPalettes[i].colors[j].hex}";></section>
+          <section class="palettes_current mini locked" style="background-color:${savedPalettes[i].colors[j].hex}";></section>
         </section>
       `
     }
@@ -78,26 +78,10 @@ function displayPalette() {
 };
 
 
-  //add a value/key to trash can img
-  // being created as part of original for loop 47
-  // savepalet.i.// ID
-  // put eventlisterner on big container
-  // target (function )( function (event))
-  //function will hit if( event.target.value.classList.
-  // does even.t.target.key === date.object // instanceof// update data model (remove from array )// maybe splice method...
-  // function renders// the dom with a function
-  //does event.target.contains(mini_trashCan
-  // queryselector (console.log() frequently)
-
-
-
-
 function makeLocked(elementLock) {
   elementLock.classList.remove('unlocked');
   elementLock.classList.add('locked');
 }
-
-
 
 function lockColor1() {
   if (!mainPalette.colors[0].locked) {


### PR DESCRIPTION
I fixed the rgb/saved palette bug by interpolating the color class hex value to include a # immediately. That way when the browser forces our data to change to rgb, it still maintains the essential color and will perform as expected. 